### PR TITLE
Changing env setup for project to make things manageable across all envs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,0 @@
-# Postgres Environment Variables
-POSTGRES_USER=<replace_me_username>
-POSTGRES_PASSWORD=<replace_me_password>
-POSTGRES_DB=<replace_me_dbname>
-
-# Client Environment Variables
-VITE_PROXY_URL=http://api:8000
-
-# Server Environment Variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,16 @@
 version: '3.8'
 services:
-  server:
+  api:
     build:
       context: ./spendaro/api
       dockerfile: Dockerfile
       target: dev
     volumes:
       - ./spendaro/api:/usr/api
-    environment:
-      # Postgres connection env variables
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB_NAME=${POSTGRES_DB}
-      - POSTGRES_SERVER=postgres #service name in compose and K8s - defaults localhost in app code
-      - POSTGRES_PORT=5432
-      # Redis env variables
-      # Secret keys env variables
-      # others...
+    env_file:
+      - ./spendaro/api/.env
     ports:
       - "8000:8000"
-    # Backend service depends on postgres and redis to spin up
     depends_on:
       - postgres
       - redis
@@ -31,8 +22,8 @@ services:
     volumes:
       - ./spendaro/client:/usr/app
       - /usr/app/node_modules
-    environment:
-      - VITE_PROXY_URL=${VITE_PROXY_URL}
+    env_file:
+      - ./spendaro/client/.env
     ports:
       - "5173:5173"
   postgres:


### PR DESCRIPTION
Removing the need to manage env vars at the top level of the project. Now the project can be managed as followed:

1. Maintain a `.env` file in the `client` directory that can be referenced in the `docker-compose.yaml` but also be used in a self-contained manner if users want to just run the client / plan to run locally outside of Docker

...same for api

2. Only the Postgres credentials are managed at the top level in a `.env` file. Once deployed in K8s, things will be leveraging `Secrets` and `ConfigMaps` to manage environment variables and credentials without the need to use .env files at all